### PR TITLE
fix / update AI Studio naming to AI Foundry

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ products:
 - azure-container-apps
 urlFragment: azureai-basic-python
 name: Azure AI basic template (Python)
-description: Creates an Azure AI Studio hub, project and required dependent resources including Azure AI Services, Azure AI Search and more. Deploys a simple chat application.
+description: Creates an Azure AI Foundry hub, project and required dependent resources including Azure AI Services, Azure AI Search and more. Deploys a simple chat application.
 ---
 <!-- YAML front-matter schema: https://review.learn.microsoft.com/en-us/help/contribute/samples/process/onboarding?branch=main#supported-metadata-fields-for-readmemd -->
 
-# Azure AI Studio Starter Template
+# Azure AI Foundry Starter Template
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Azure-Samples/azureai-basic-python)
 [![Open in Dev Containers](https://img.shields.io/static/v1?style=for-the-badge&label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/Azure-Samples/azureai-basic-python)
 
-This project creates an Azure AI Studio hub, project and connected resources including Azure AI Services, AI Search and more. It also deploys a simple chat application to Azure Container Apps.
+This project creates an Azure AI Foundry hub, project and connected resources including Azure AI Services, AI Search and more. It also deploys a simple chat application to Azure Container Apps.
 
 * [Features](#features)
 * [Architecture diagram](#architecture-diagram)
@@ -36,7 +36,7 @@ This project creates an Azure AI Studio hub, project and connected resources inc
 
 ## Features
 
-This template creates everything you need to get started with Azure AI Studio:
+This template creates everything you need to get started with Azure AI Foundry:
 
 * [AI Hub Resource](https://learn.microsoft.com/azure/ai-studio/concepts/ai-resources)
 * [AI Project](https://learn.microsoft.com/azure/ai-studio/how-to/create-projects)
@@ -139,7 +139,7 @@ or [customize the models](docs/deploy_customization.md#customizing-model-deploym
 
 ### Bringing an existing AI project resource
 
-If you have an existing AI project resource, you can bring it into the Azure AI Studio Starter Template by setting the following environment variable:
+If you have an existing AI project resource, you can bring it into the Azure AI Foundry Starter Template by setting the following environment variable:
 
 ```shell
 azd env set AZURE_EXISTING_AIPROJECT_CONNECTION_STRING "<connection-string>"
@@ -147,7 +147,7 @@ azd env set AZURE_EXISTING_AIPROJECT_CONNECTION_STRING "<connection-string>"
 
 You can find the connection string on the overview page of your Azure AI project.
 
-If you do not have a deployment named "gpt-4o-mini" in your existing AI project, you should either create one in Azure AI studio or follow the steps in [Customizing model deployments](#customizing-model-deployments) to specify a different model.
+If you do not have a deployment named "gpt-4o-mini" in your existing AI project, you should either create one in Azure AI Foundry or follow the steps in [Customizing model deployments](#customizing-model-deployments) to specify a different model.
 
 ## Development server
 
@@ -201,7 +201,7 @@ However, Azure Container Registry has a fixed cost per registry per day.
 
 You can try the [Azure pricing calculator](https://azure.microsoft.com/en-us/pricing/calculator) for the resources:
 
-* Azure AI Studio: Free tier. [Pricing](https://azure.microsoft.com/pricing/details/ai-studio/)
+* Azure AI Foundry: Free tier. [Pricing](https://azure.microsoft.com/pricing/details/ai-studio/)
 * Azure AI Search: Standard tier, S1. Pricing is based on the number of documents and operations. [Pricing](https://azure.microsoft.com/pricing/details/search/)
 * Azure Storage Account: Standard tier, LRS. Pricing is based on storage and operations. [Pricing](https://azure.microsoft.com/pricing/details/storage/blobs/)
 * Azure Key Vault: Standard tier. Pricing is based on the number of operations. [Pricing](https://azure.microsoft.com/pricing/details/key-vault/)
@@ -215,7 +215,7 @@ either by deleting the resource group in the Portal or running `azd down`.
 
 ### Security guidelines
 
-This template uses Azure AI Studio connections to communicate between resources, which stores keys in Azure Key Vault.
+This template uses Azure AI Foundry connections to communicate between resources, which stores keys in Azure Key Vault.
 This template also uses [Managed Identity](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview) for local development and deployment.
 
 To ensure continued best practices in your own repository, we recommend that anyone creating solutions based on our templates ensure that the [Github secret scanning](https://docs.github.com/code-security/secret-scanning/about-secret-scanning) setting is enabled.

--- a/docs/deploy_customization.md
+++ b/docs/deploy_customization.md
@@ -1,7 +1,7 @@
 
-# Azure AI Studio Starter Template: Deployment customization
+# Azure AI Foundry Starter Template: Deployment customization
 
-This document describes how to customize the deployment of the Azure AI Studio Starter Template. Once you follow the steps here, you can run `azd up` as described in the [Deploying](./README.md#deploying) steps.
+This document describes how to customize the deployment of the Azure AI Foundry Starter Template. Once you follow the steps here, you can run `azd up` as described in the [Deploying](./README.md#deploying) steps.
 
 * [Disabling resources](#disabling-resources)
 * [Customizing resource names](#customizing-resource-names)
@@ -20,9 +20,9 @@ Then run `azd up` to deploy the remaining resources.
 By default this template will use a default naming convention to prevent naming collisions within Azure.
 To override default naming conventions the following can be set.
 
-* `AZURE_AIHUB_NAME` - The name of the AI Studio Hub resource
-* `AZURE_AIPROJECT_NAME` - The name of the AI Studio Project
-* `AZURE_AIENDPOINT_NAME` - The name of the AI Studio online endpoint used for deployments
+* `AZURE_AIHUB_NAME` - The name of the AI Foundry Hub resource
+* `AZURE_AIPROJECT_NAME` - The name of the AI Foundry Project
+* `AZURE_AIENDPOINT_NAME` - The name of the AI Foundry online endpoint used for deployments
 * `AZURE_AISERVICES_NAME` - The name of the Azure AI service
 * `AZURE_SEARCH_SERVICE_NAME` - The name of the Azure Search service
 * `AZURE_STORAGE_ACCOUNT_NAME` - The name of the Storage Account
@@ -93,7 +93,7 @@ azd env set AZURE_AI_EMBED_DEPLOYMENT_SKU Standard
 
 ## Bringing an existing AI project resource
 
-If you have an existing AI project resource, you can bring it into the Azure AI Studio Starter Template by setting the following environment variable:
+If you have an existing AI project resource, you can bring it into the Azure AI Foundry Starter Template by setting the following environment variable:
 
 ```shell
 azd env set AZURE_EXISTING_AIPROJECT_CONNECTION_STRING "<connection-string>"
@@ -101,4 +101,4 @@ azd env set AZURE_EXISTING_AIPROJECT_CONNECTION_STRING "<connection-string>"
 
 You can find the connection string on the overview page of your Azure AI project.
 
-If you do not have a deployment named "gpt-4o-mini" in your existing AI project, you should either create one in Azure AI studio or follow the steps in [Customizing model deployments](#customizing-model-deployments) to specify a different model.
+If you do not have a deployment named "gpt-4o-mini" in your existing AI project, you should either create one in Azure AI Foundry or follow the steps in [Customizing model deployments](#customizing-model-deployments) to specify a different model.

--- a/infra/core/ai/hub.bicep
+++ b/infra/core/ai/hub.bicep
@@ -1,33 +1,33 @@
-@description('The AI Studio Hub Resource name')
+@description('The AI Foundry Hub Resource name')
 param name string
-@description('The display name of the AI Studio Hub Resource')
+@description('The display name of the AI Foundry Hub Resource')
 param displayName string = name
-@description('The storage account ID to use for the AI Studio Hub Resource')
+@description('The storage account ID to use for the AI Foundry Hub Resource')
 param storageAccountId string
-@description('The key vault ID to use for the AI Studio Hub Resource')
+@description('The key vault ID to use for the AI Foundry Hub Resource')
 param keyVaultId string
-@description('The application insights ID to use for the AI Studio Hub Resource')
+@description('The application insights ID to use for the AI Foundry Hub Resource')
 param applicationInsightsId string = ''
-@description('The container registry ID to use for the AI Studio Hub Resource')
+@description('The container registry ID to use for the AI Foundry Hub Resource')
 param containerRegistryId string = ''
-@description('The AI Services account name to use for the AI Studio Hub Resource')
+@description('The AI Services account name to use for the AI Foundry Hub Resource')
 param aiServicesName string
-@description('The AI Services connection name to use for the AI Studio Hub Resource')
+@description('The AI Services connection name to use for the AI Foundry Hub Resource')
 param aiServicesConnectionName string
-@description('The AI Services Content Safety connection name to use for the AI Studio Hub Resource')
+@description('The AI Services Content Safety connection name to use for the AI Foundry Hub Resource')
 param aiServicesContentSafetyConnectionName string
-@description('The Azure Cognitive Search service name to use for the AI Studio Hub Resource')
+@description('The Azure Cognitive Search service name to use for the AI Foundry Hub Resource')
 param aiSearchName string = ''
-@description('The Azure Cognitive Search service connection name to use for the AI Studio Hub Resource')
+@description('The Azure Cognitive Search service connection name to use for the AI Foundry Hub Resource')
 param aiSearchConnectionName string
 
 
-@description('The SKU name to use for the AI Studio Hub Resource')
+@description('The SKU name to use for the AI Foundry Hub Resource')
 param skuName string = 'Basic'
-@description('The SKU tier to use for the AI Studio Hub Resource')
+@description('The SKU tier to use for the AI Foundry Hub Resource')
 @allowed(['Basic', 'Free', 'Premium', 'Standard'])
 param skuTier string = 'Basic'
-@description('The public network access setting to use for the AI Studio Hub Resource')
+@description('The public network access setting to use for the AI Foundry Hub Resource')
 @allowed(['Enabled','Disabled'])
 param publicNetworkAccess string = 'Enabled'
 

--- a/infra/core/ai/project.bicep
+++ b/infra/core/ai/project.bicep
@@ -1,18 +1,18 @@
-@description('The AI Studio Hub Resource name')
+@description('The AI Foundry Hub Resource name')
 param name string
-@description('The display name of the AI Studio Hub Resource')
+@description('The display name of the AI Foundry Hub Resource')
 param displayName string = name
-@description('The name of the AI Studio Hub Resource where this project should be created')
+@description('The name of the AI Foundry Hub Resource where this project should be created')
 param hubName string
 @description('The name of the key vault resource to grant access to the project')
 param keyVaultName string
 
-@description('The SKU name to use for the AI Studio Hub Resource')
+@description('The SKU name to use for the AI Foundry Hub Resource')
 param skuName string = 'Basic'
-@description('The SKU tier to use for the AI Studio Hub Resource')
+@description('The SKU tier to use for the AI Foundry Hub Resource')
 @allowed(['Basic', 'Free', 'Premium', 'Standard'])
 param skuTier string = 'Basic'
-@description('The public network access setting to use for the AI Studio Hub Resource')
+@description('The public network access setting to use for the AI Foundry Hub Resource')
 @allowed(['Enabled','Disabled'])
 param publicNetworkAccess string = 'Enabled'
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -44,9 +44,9 @@ param location string
 param aiExistingProjectConnectionString string = ''
 @description('The Azure resource group where new resources will be deployed')
 param resourceGroupName string = ''
-@description('The Azure AI Studio Hub resource name. If ommited will be generated')
+@description('The Azure AI Foundry Hub resource name. If ommited will be generated')
 param aiHubName string = ''
-@description('The Azure AI Studio project name. If ommited will be generated')
+@description('The Azure AI Foundry project name. If ommited will be generated')
 param aiProjectName string = ''
 @description('The application insights resource name. If ommited will be generated')
 param applicationInsightsName string = ''


### PR DESCRIPTION
1. Updated references to "AI Studio" to reflect new "AI Foundry" naming. 
2. Validated that the template worked as expected for `azd up` with my subscription.

**Exceptions**

1. The `azure.yaml` uses `azd-aistudio-starter` as the template name. This should be changed but was not sure of existing dependencies that may be affected.

1. The README mentions we should turn _off_ AI SEARCH if needed. In reality the default behavior is off and we need to turn it _on_ if needed before `azd up`.